### PR TITLE
Make release tags selectable

### DIFF
--- a/cockpit-runner/MainWindow.axaml
+++ b/cockpit-runner/MainWindow.axaml
@@ -3,7 +3,9 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:svg="clr-namespace:Avalonia.Svg;assembly=Avalonia.Svg"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        mc:Ignorable="d"
+		Width="700"
+		Height="450"
         x:Class="cockpit_runner.MainWindow"
         Title="AI Cockpit Runner">
     <Grid x:Name="global">
@@ -29,7 +31,9 @@
                     <Label VerticalAlignment="Center" Margin="5,1,0,1" FontSize="12" >Scenario</Label>
                     <ComboBox VerticalAlignment="Center" Margin="5,1,0,1" Width="100" x:Name="SelectScenario" SelectionChanged="BinaryScenarioSelected" />
 					<ComboBox IsVisible="False" VerticalAlignment="Center" Margin="5,1,0,1" Width="100" x:Name="SelectLanguage" />
-                </StackPanel>
+					<ComboBox IsVisible="True" VerticalAlignment="Center" Margin="5,1,0,1" Width="100" x:Name="SelectTag" />
+					<Button IsEnabled="True" VerticalAlignment="Center" Margin="5,1,0,1" Click="SwitchVersion_Click" x:Name="SwitchVersion">Switch Version</Button>
+				</StackPanel>
             </Border>
             <ScrollViewer Grid.Row="1" x:Name="ActionOutputScroller">
                 <Grid Grid.Row="1">

--- a/cockpit-runner/MainWindow.axaml.cs
+++ b/cockpit-runner/MainWindow.axaml.cs
@@ -31,19 +31,22 @@ public partial class MainWindow : Window
         git.CheckIfCodeiIsPresent(standardTag);
         ActionOutput.Text += "AI Cockpit code ready\n";
 
-        List<string> scenarios = git.GetAvailableBinaryScenarios();
-        SelectScenario.ItemsSource = scenarios;
-        SelectScenario.SelectedIndex = 0;
+        git.GetAvailableBinaryScenarios(SelectScenario);
+        df.CheckIfCockpitIsRunning();
     }
 
     private void BinaryScenarioSelected(object sender, SelectionChangedEventArgs e)
     {
-        var scenario = SelectScenario.SelectedItem.ToString();
+        Trace.WriteLine(string.Join(" ", SelectScenario.Items));
+        if(SelectScenario.SelectedItem != null)
+        {
+            var scenario = SelectScenario.SelectedItem.ToString();
 
-        List<string> scenarioLanguages = git.GetAvailableScenarioLanguages(scenario);
-        SelectLanguage.ItemsSource = scenarioLanguages;
-        SelectLanguage.SelectedIndex = 0;
-        SelectLanguage.IsVisible = true;
+            List<string> scenarioLanguages = git.GetAvailableScenarioLanguages(scenario);
+            SelectLanguage.ItemsSource = scenarioLanguages;
+            SelectLanguage.SelectedIndex = 0;
+            SelectLanguage.IsVisible = true;
+        }
     }
 
     private void StartStopCockpit_Click(object sender, RoutedEventArgs args)
@@ -59,11 +62,11 @@ public partial class MainWindow : Window
                 "This will checkout a different AI Cockpit version. All local modifications will be lost. Continue?", 
                 MsBox.Avalonia.Enums.ButtonEnum.OkCancel);
         var result = await alertBox.ShowWindowDialogAsync(this);
-        Trace.WriteLine(result);
         if(result.Equals(ButtonResult.Ok))
         {
             ActionOutput.Text += "Delete existing code and checkout tag... \n";
             git.CheckOutTag(SelectTag.SelectedItem.ToString());
+            git.GetAvailableBinaryScenarios(SelectScenario);
         }
     }
 

--- a/cockpit-runner/cockpit-runner.csproj
+++ b/cockpit-runner/cockpit-runner.csproj
@@ -15,6 +15,10 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <StartupObject>cockpit_runner.Program</StartupObject>
     <ApplicationIcon>assets\logo starwit.ico</ApplicationIcon>
+
+	<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+	<ImplicitUsings>enable</ImplicitUsings>
+	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,6 +46,7 @@
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
+    <PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />
     <PackageReference Include="Svg.Skia" Version="2.0.0.4" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />	  
   </ItemGroup>

--- a/cockpit-runner/docker/DockerFunctions.cs
+++ b/cockpit-runner/docker/DockerFunctions.cs
@@ -17,7 +17,7 @@ internal class DockerFunctions()
 
     private string cockpitDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aicockpit");
 
-    private MainWindow mainWindow;
+    private readonly MainWindow mainWindow;
 
     public DockerFunctions(MainWindow mainWindow): this()
     {
@@ -31,12 +31,12 @@ internal class DockerFunctions()
             var isInstalled = CheckDockerDesktop();
             if (isInstalled)
             {
-                mainWindow.ActionOutput.Text += "Started Docker Desktop.";
+                mainWindow.ActionOutput.Text += "Started Docker Desktop.\n";
                 mainWindow.StartStopCockpitBtn.IsEnabled = true;
             }
             else
             {
-                mainWindow.ActionOutput.Text += "Could not start Docker Desktop, please install.";
+                mainWindow.ActionOutput.Text += "Could not start Docker Desktop, please install.\n";
             }
         }
 

--- a/cockpit-runner/gitandcockpit/GitFunctions.cs
+++ b/cockpit-runner/gitandcockpit/GitFunctions.cs
@@ -98,7 +98,7 @@ internal class GitAndCockpit
         }
     }
 
-    public List<string> GetAvailableBinaryScenarios()
+    public void GetAvailableBinaryScenarios(ComboBox SelectScenario)
     {
         var scenarios = new List<string>();
         string[] binaryDataFolder = { cockpitDir, "docker-compose", "scenariodata", "binary_data" };
@@ -107,12 +107,16 @@ internal class GitAndCockpit
         {
             foreach (var dir in Directory.GetDirectories(binaryDir))
             {
+                Trace.WriteLine($"{dir}");
                 scenarios.Add(Path.GetFileName(dir));
-            };
+            }
         } catch (Exception ex) 
-        { Trace.WriteLine(ex.Message); }
+        { 
+            Trace.WriteLine(ex.Message);
+        }
 
-        return scenarios;
+        SelectScenario.ItemsSource = scenarios;
+        SelectScenario.SelectedIndex = 1;
     }
 
     public List<string> GetAvailableScenarioLanguages(string binaryScenario)

--- a/cockpit-runner/gitandcockpit/GitFunctions.cs
+++ b/cockpit-runner/gitandcockpit/GitFunctions.cs
@@ -1,7 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Text.Json;
 using LibGit2Sharp;
+using Avalonia.Controls;
+using System.Text.Json.Serialization;
+using System.Diagnostics;
 
 namespace cockpit_runner.gitandcockpit;
 
@@ -9,28 +15,86 @@ internal class GitAndCockpit
 {
     private string cockpitDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aicockpit");
     string gitUrl = "https://github.com/starwit/ai-cockpit-deployment.git";
-    
-    public void CheckIfCodeiIsPresent()
+
+    public async Task GetTagList(ComboBox SelectTag)
     {
-        Directory.CreateDirectory(cockpitDir);
-        // check if dir is empty
-        if(Directory.GetFiles(cockpitDir).Length == 0 && Directory.GetDirectories(cockpitDir).Length == 0)
+        using (HttpClient httpClient = new HttpClient())
         {
-            // if not clone repo
-            Repository.Clone(gitUrl, cockpitDir);
-        } else
-        {
-            // pull latest code
-            var signature = new Signature("Your Name", "your.email@example.com", DateTimeOffset.Now);
-            var repo = new Repository(cockpitDir);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "AICockpit-Runner");
             try
             {
-                Commands.Pull(repo, signature, new PullOptions());
-            } catch (LibGit2SharpException e)
-            {
-                Console.WriteLine(e.Message);
+                HttpResponseMessage response = await httpClient.GetAsync("https://api.github.com/repos/starwit/ai-cockpit-deployment/tags");
+                response.EnsureSuccessStatusCode();
+                string responseBody = await response.Content.ReadAsStringAsync();
+                try
+                {
+                    var tags = JsonSerializer.Deserialize(responseBody, GitHubTagContext.Default.ListGitHubTag);
+                    var tagNames = new List<string>();
+                    foreach (var tag in tags)
+                    {
+                        tagNames.Add(tag.Name);
+                    }
+                    SelectTag.ItemsSource = tagNames;
+                    SelectTag.SelectedIndex = 0;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.Message);
+                }
             }
-            
+            catch (Exception ex)
+            {
+               Console.WriteLine(ex.Message); 
+            }   
+        }
+    }
+    
+    public void CheckIfCodeiIsPresent(string tagName)
+    {
+        if(Directory.Exists(cockpitDir) && Directory.GetFiles(cockpitDir).Length == 0)
+        {
+            Trace.WriteLine("Checkout directory exists but is empty");
+            DeleteDirectory(cockpitDir);
+        }
+        Directory.CreateDirectory(cockpitDir);
+        // check if dir is empty
+        if (Directory.GetFiles(cockpitDir).Length == 0 && Directory.GetDirectories(cockpitDir).Length == 0)
+        {
+            try
+            {
+                var path = Repository.Clone(gitUrl, cockpitDir);
+
+                // checkout selected tag
+                var repositoryOptions = new RepositoryOptions { WorkingDirectoryPath = path };
+                var checkoutOptions = new CheckoutOptions { };
+                using (var repo = new Repository(path, repositoryOptions))
+                {
+                    Tag tag = repo.Tags[tagName];
+                    Trace.WriteLine(tag);
+                    Commit commit = tag.Target is Commit c ? c : ((TagAnnotation)tag.Target).Target as Commit;
+                    Trace.WriteLine(commit);
+                    repo.Reset(ResetMode.Hard, commit);
+                    repo.CheckoutPaths(commit.Sha, new[] { "." }, new CheckoutOptions());
+                }
+                Trace.WriteLine("Checkout repository");
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine(ex.Message);
+            }
+        }
+    }
+
+    public void CheckOutTag(string tag)
+    {
+        try
+        {
+            DeleteDirectory(cockpitDir);
+            CheckIfCodeiIsPresent(tag);
+        }
+        catch (Exception ex)
+        {
+            Trace.WriteLine(ex.Message);
         }
     }
 
@@ -39,10 +103,14 @@ internal class GitAndCockpit
         var scenarios = new List<string>();
         string[] binaryDataFolder = { cockpitDir, "docker-compose", "scenariodata", "binary_data" };
         var binaryDir = Path.Combine(binaryDataFolder);
-        foreach (var dir in Directory.GetDirectories(binaryDir))
+        try
         {
-            scenarios.Add(Path.GetFileName(dir));
-        };
+            foreach (var dir in Directory.GetDirectories(binaryDir))
+            {
+                scenarios.Add(Path.GetFileName(dir));
+            };
+        } catch (Exception ex) 
+        { Trace.WriteLine(ex.Message); }
 
         return scenarios;
     }
@@ -59,5 +127,26 @@ internal class GitAndCockpit
             scenarios.Add(Path.GetFileName(lang));
         }
         return scenarios;
+    }
+
+    private static void DeleteDirectory(string targetDir)
+    {
+        File.SetAttributes(targetDir, FileAttributes.Normal);
+
+        string[] files = Directory.GetFiles(targetDir);
+        string[] dirs = Directory.GetDirectories(targetDir);
+
+        foreach (string file in files)
+        {
+            File.SetAttributes(file, FileAttributes.Normal);
+            File.Delete(file);
+        }
+
+        foreach (string dir in dirs)
+        {
+            DeleteDirectory(dir);
+        }
+
+        Directory.Delete(targetDir, false);
     }
 }

--- a/cockpit-runner/gitandcockpit/GitHubTag.cs
+++ b/cockpit-runner/gitandcockpit/GitHubTag.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace cockpit_runner.gitandcockpit;
+
+public class GitHubTag
+{
+    public string Name { get; set; }
+}

--- a/cockpit-runner/gitandcockpit/GitHubTagContext.cs
+++ b/cockpit-runner/gitandcockpit/GitHubTagContext.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace cockpit_runner.gitandcockpit;
+
+[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(List<GitHubTag>))]
+public partial class GitHubTagContext : JsonSerializerContext
+{
+}
+


### PR DESCRIPTION
Runner displays available release tags for AI Cockpit

## Description
When new versions of AI Cockpit are released, users shall be able to select, which version to run.

## How has this been tested?
Manual testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
